### PR TITLE
add muon beam current

### DIFF
--- a/ioc/ISISBEAM/iocBoot/iocisisbeam/params.txt
+++ b/ioc/ISISBEAM/iocBoot/iocisisbeam/params.txt
@@ -6,6 +6,7 @@ beam_e1          float    t  -60    LOCAL::BEAM:EPB1
 beam_tgt         float    t  -60     LOCAL::BEAM:TARGET
 beam_tgt2        float    t  -60     LOCAL::BEAM:TARGET2
 beam_energy      long     t  0     LOCAL::BEAM:ENERGY 
+beam_muon        float    t  0     INTENSITY::MUON:CURRENT
 inj_eff          float    t  0     LOCAL::intensity:inj_eff
 acc_eff          float    t  0     LOCAL::intensity:acc_eff
 ext_eff          float    t  0     LOCAL::intensity:ext_eff

--- a/ioc/ISISBEAM/iocBoot/iocisisbeam/params.txt
+++ b/ioc/ISISBEAM/iocBoot/iocisisbeam/params.txt
@@ -1,12 +1,12 @@
-beam_ions        float    t  0    IDTOR::IRT1:CURRENT
-beam_rfq         float    t  0    IDTOR::IRT3:CURRENT
-beam_linac       float    t  0    IDTOR::IHT5:CURRENT
+beam_ions        float    t  0    IDINT::IRT1:CURRENT
+beam_rfq         float    t  0    IDINT::IRT3:CURRENT
+beam_linac       float    t  0    IDINT::IHT5:CURRENT
 beam_sync        float    t  -60    LOCAL::BEAM:SYNCHROTRON
 beam_e1          float    t  -60    LOCAL::BEAM:EPB1
 beam_tgt         float    t  -60     LOCAL::BEAM:TARGET
 beam_tgt2        float    t  -60     LOCAL::BEAM:TARGET2
+beam_muon        float    t  -60     INTENSITY::MUON:CURRENT
 beam_energy      long     t  0     LOCAL::BEAM:ENERGY 
-beam_muon        float    t  0     INTENSITY::MUON:CURRENT
 inj_eff          float    t  0     LOCAL::intensity:inj_eff
 acc_eff          float    t  0     LOCAL::intensity:acc_eff
 ext_eff          float    t  0     LOCAL::intensity:ext_eff

--- a/ioc/ISISBEAM/isisbeamApp/Db/beam.substitutions
+++ b/ioc/ISISBEAM/isisbeamApp/Db/beam.substitutions
@@ -6,3 +6,4 @@ pattern { BEAM, PARAM, LOW, LOPR, HOPR }
 { "IONS", "beam_ions", "0", "0", "300" }
 { "RFQ", "beam_rfq", "0", "0", "300" }
 { "LINAC", "beam_linac", "0", "0", "300" }
+{ "MUON", "beam_muon", "0", "0", "10" }


### PR DESCRIPTION
From Merckx:
```
$ db_access INTENSITY::MUON:CURRENT
Channel Name: MUON:CURRENT
Local Channel Index: 72
Label: 1 second average muon current
Upper Equipment Limit: DEFAULTED
Lower Equipment Limit: DEFAULTED
Upper Display Limit: 0.000000
Lower Display Limit: 0.000000
Slope: 0.000000
Offset: 0.000000
Format: E10.2
Units:  uA
Delta: 0.000000
Size: 1
Element         External Value
[0]               5.94E+00
```
